### PR TITLE
chore: bump version to 0.6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,81 +540,130 @@ jobs:
       - name: Build Python wheel
         run: maturin build --release
 
-  # Publish to crates.io (commented out - uncomment when ready to publish)
+  # Publish to crates.io and create release tag
   # This job runs only after all CI checks pass successfully
-  # publish:
-  #   name: Publish to crates.io
-  #   runs-on: ubuntu-latest
-  #   needs: [lint, test-linux, test-macos, test-windows, build, python-build, coverage]
-  #   # Note: All checks including coverage must pass before publishing
-  #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-  #   permissions:
-  #     contents: write  # Required to create and push git tags
-  #     pull-requests: read
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0  # Required for git tag operations
-  #         token: ${{ secrets.GITHUB_TOKEN }}  # Required for pushing tags
-  #     
-  #     - name: Install Rust
-  #       uses: dtolnay/rust-toolchain@stable
-  #     
-  #     - name: Cache cargo registry
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/registry/index/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/git/db/
-  #           target/
-  #         key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-cargo-
-  #     
-  #     - name: Get version from Cargo.toml
-  #       id: version
-  #       run: |
-  #         VERSION=$(grep '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
-  #         echo "version=$VERSION" >> $GITHUB_OUTPUT
-  #         echo "Version: $VERSION"
-  #     
-  #     - name: Check if tag already exists
-  #       id: check-tag
-  #       run: |
-  #         if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-  #           echo "exists=true" >> $GITHUB_OUTPUT
-  #           echo "Tag v${{ steps.version.outputs.version }} already exists"
-  #         else
-  #           echo "exists=false" >> $GITHUB_OUTPUT
-  #           echo "Tag v${{ steps.version.outputs.version }} does not exist"
-  #         fi
-  #     
-  #     - name: Create git tag
-  #       if: steps.check-tag.outputs.exists == 'false'
-  #       run: |
-  #         git config user.name "github-actions[bot]"
-  #         git config user.email "github-actions[bot]@users.noreply.github.com"
-  #         git tag -a "v${{ steps.version.outputs.version }}" -m "Release v${{ steps.version.outputs.version }}"
-  #         git push origin "v${{ steps.version.outputs.version }}"
-  #       # Note: GITHUB_TOKEN is automatically available when permissions are set above
-  #     
-  #     - name: Verify package is ready for publishing
-  #       run: |
-  #         cargo package --dry-run
-  #         cargo publish --dry-run
-  #     
-  #     - name: Build crate package
-  #       run: cargo package
-  #     
-  #     - name: Publish to crates.io
-  #       # Uncomment the following lines when ready to actually publish
-  #       # run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
-  #       run: |
-  #         echo "Publish step is commented out. To enable:"
-  #         echo "1. Add CRATES_IO_TOKEN to repository secrets"
-  #         echo "2. Uncomment the 'cargo publish' command above"
-  #         echo "3. Uncomment this job in the workflow file"
-  #         echo "Package built successfully and ready for publishing"
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    needs: [lint, test-linux, test-macos, test-windows, build, python-build, coverage]
+    # Note: All checks including coverage must pass before publishing
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write  # Required to create and push git tags
+      issues: write    # Required to close referenced issues
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for git tag operations
+          token: ${{ secrets.GITHUB_TOKEN }}  # Required for pushing tags and closing issues
+      
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      
+      - name: Get version from Cargo.toml
+        id: version
+        run: |
+          VERSION=$(grep '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+      
+      - name: Check if tag already exists
+        id: check-tag
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Tag v${{ steps.version.outputs.version }} already exists"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Tag v${{ steps.version.outputs.version }} does not exist"
+          fi
+      
+      - name: Create git tag
+        if: steps.check-tag.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${{ steps.version.outputs.version }}" -m "Release v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"
+        # Note: GITHUB_TOKEN is automatically available when permissions are set above
+      
+      - name: Extract referenced issues from commits
+        id: extract-issues
+        run: |
+          # Get commits since last tag (or all commits if no tag exists)
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            COMMITS=$(git log --pretty=format:"%s %b" --no-merges)
+          else
+            COMMITS=$(git log ${LAST_TAG}..HEAD --pretty=format:"%s %b" --no-merges)
+          fi
+          
+          # Extract issue numbers from commit messages
+          # Patterns: "closes #123", "fixes #456", "resolves #789", or just "#123"
+          ISSUES=$(echo "$COMMITS" | grep -oE '(closes|fixes|resolves|implements|addresses)?\s*#?[0-9]+' | grep -oE '[0-9]+' | sort -u | tr '\n' ' ' || echo "")
+          
+          if [ -z "$ISSUES" ]; then
+            echo "No referenced issues found in commits"
+            echo "issues=" >> $GITHUB_OUTPUT
+          else
+            echo "Found referenced issues: $ISSUES"
+            echo "issues=$ISSUES" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Close referenced issues
+        if: steps.extract-issues.outputs.issues != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          ISSUES="${{ steps.extract-issues.outputs.issues }}"
+          
+          for issue in $ISSUES; do
+            echo "Checking issue #$issue..."
+            
+            # Check if issue exists and is open
+            ISSUE_STATE=$(gh issue view $issue --repo ${{ github.repository }} --json state -q .state 2>/dev/null || echo "notfound")
+            
+            if [ "$ISSUE_STATE" = "notfound" ]; then
+              echo "  Issue #$issue not found, skipping"
+              continue
+            elif [ "$ISSUE_STATE" = "closed" ]; then
+              echo "  Issue #$issue is already closed, skipping"
+              continue
+            elif [ "$ISSUE_STATE" = "open" ]; then
+              echo "  Closing issue #$issue..."
+              gh issue close $issue --repo ${{ github.repository }} --comment "Closed automatically as part of release v$VERSION. This issue was referenced in the release commits." || echo "  Failed to close issue #$issue"
+            fi
+          done
+      
+      - name: Verify package is ready for publishing
+        run: |
+          cargo package --dry-run
+          cargo publish --dry-run
+      
+      - name: Build crate package
+        run: cargo package
+      
+      - name: Publish to crates.io
+        # Uncomment the following lines when ready to actually publish
+        # run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
+        run: |
+          echo "Publish step is commented out. To enable:"
+          echo "1. Add CRATES_IO_TOKEN to repository secrets"
+          echo "2. Uncomment the 'cargo publish' command above"
+          echo "Package built successfully and ready for publishing"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2025-12-11
+
+### Changed
+- **CI/CD Pipeline**: Enabled publish job with automatic tag creation and issue closing
+  - Publish job now creates git tags automatically on release
+  - Automatically closes referenced GitHub issues when release is published
+  - Removed CHANGELOG and pyproject.toml updates from CI (handled locally)
+
 ## [0.6.0] - 2025-12-11
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "otlp-arrow-library"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 authors = ["OTLP Rust Service Team"]
 description = "Cross-platform Rust library for receiving OTLP messages via gRPC and writing to Arrow IPC files"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "otlp-arrow-library"
-version = "0.6.0"
+version = "0.6.1"
 requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Rust",
@@ -14,7 +14,7 @@ classifiers = [
 
 [project.metadata]
 description = "OTLP Arrow Flight Library - Python bindings"
-version = "0.6.0"
+version = "0.6.1"
 
 [tool.maturin]
 features = ["python-extension"]


### PR DESCRIPTION
## Summary

Bump version to 0.6.1 and enable publish job with automatic tag creation and issue closing.

## Changes

### Version Bump
- Updated Cargo.toml version to **0.6.1**
- Updated pyproject.toml version to **0.6.1** (both locations)
- Added CHANGELOG.md entry for 0.6.1

### CI/CD Improvements
- **Enabled publish job**: Uncommented and enhanced the publish job in CI workflow
- **Automatic tag creation**: Creates git tag (e.g., `v0.6.1`) automatically when publishing
- **Issue closing**: Automatically closes referenced GitHub issues when release is published
  - Extracts issue numbers from commit messages (supports: closes, fixes, resolves, implements, addresses, or just #123)
  - Adds comment indicating issue was closed as part of release
- **Removed CHANGELOG/pyproject updates**: These are now handled locally before commit (as they should be)

## Testing

- [x] Version consistency validated (Cargo.toml, pyproject.toml, CHANGELOG.md)
- [x] GPG signed commit
- [x] Pre-commit checks pass

## Related

This PR enables the automated release workflow that will:
1. Create git tags automatically
2. Close referenced issues automatically
3. Prepare package for publishing to crates.io