### PR TITLE
chore: enable automatic publishing to crates.io (v0.6.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2025-12-11
+
+### Changed
+- **CI/CD Pipeline**: Enabled automatic publishing to crates.io
+  - Uncommented `cargo publish` command in publish workflow
+  - Publishing now occurs automatically when all CI checks pass on main branch
+
 ## [0.6.2] - 2025-12-11
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "otlp-arrow-library"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 authors = ["OTLP Rust Service Team"]
 description = "Cross-platform Rust library for receiving OTLP messages via gRPC and writing to Arrow IPC files"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "otlp-arrow-library"
-version = "0.6.2"
+version = "0.6.3"
 requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Rust",
@@ -14,7 +14,7 @@ classifiers = [
 
 [project.metadata]
 description = "OTLP Arrow Flight Library - Python bindings"
-version = "0.6.2"
+version = "0.6.3"
 
 [tool.maturin]
 features = ["python-extension"]


### PR DESCRIPTION
This PR enables automatic publishing to crates.io when all CI checks pass on main branch.

## Changes
- Uncommented `cargo publish` command in CI workflow
- Bump version to 0.6.3
- Update CHANGELOG

## Notes
- Publishing requires `CARGO_REGISTRY_TOKEN` secret to be configured in repository settings
- Publishing only occurs on pushes to main branch after all CI checks pass