### PR TITLE
fix: enable cargo publish command in CI workflow (v0.6.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -675,11 +675,5 @@ jobs:
           cargo publish --dry-run --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
       
       - name: Publish to crates.io
-        # Uncomment the following lines when ready to actually publish
-        # run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          echo "Publish step is commented out. To enable:"
-          echo "1. Add CARGO_REGISTRY_TOKEN to repository secrets (crates.io API token)"
-          echo "2. Uncomment the 'cargo publish' command above"
-          echo "Package built successfully and ready for publishing"
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4] - 2025-12-11
+
+### Fixed
+- **CI/CD Pipeline**: Enable cargo publish command in CI workflow
+  - Uncommented `cargo publish` command that was missing from v0.6.3 release
+  - Publishing now occurs automatically when all CI checks pass on main branch
+
 ## [0.6.3] - 2025-12-11
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "otlp-arrow-library"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 authors = ["OTLP Rust Service Team"]
 description = "Cross-platform Rust library for receiving OTLP messages via gRPC and writing to Arrow IPC files"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "otlp-arrow-library"
-version = "0.6.3"
+version = "0.6.4"
 requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Rust",
@@ -14,7 +14,7 @@ classifiers = [
 
 [project.metadata]
 description = "OTLP Arrow Flight Library - Python bindings"
-version = "0.6.3"
+version = "0.6.4"
 
 [tool.maturin]
 features = ["python-extension"]


### PR DESCRIPTION
PR #35 was merged but only included version bump and CHANGELOG. This PR adds the missing workflow change to actually enable publishing.

## Changes
- Uncomment `cargo publish` command in CI workflow
- Bump version to 0.6.4
- Update CHANGELOG
- Publishing will now occur automatically when all CI checks pass on main branch

## Context
- PR #35 merged commit `2d49306` only included version/CHANGELOG changes
- The workflow file change was in a later commit that wasn't included in the merge